### PR TITLE
add ability to set video resolution

### DIFF
--- a/doorpi/sipphone/from_linphone.py
+++ b/doorpi/sipphone/from_linphone.py
@@ -202,6 +202,7 @@ class LinPhone(SipphoneAbstractBaseClass):
         if len(camera):
             self.core.video_capture_enabled = True
             self.core.video_device = camera
+            self.core.preferred_video_size_by_name = conf.get(SIPPHONE_SECTION, 'video_size', '')
         else:
             self.core.video_capture_enabled = False
 


### PR DESCRIPTION
At least in my setup, linphone uses a default resolution of 320x240 for video calls with my raspberry camera. This change adds the ability to set the "preferred video size by name" (see [Linphone Dokumentation](http://pythonhosted.org/linphone/api_reference.html#linphone.Core.preferred_video_size_by_name)) in the config file by setting "video_size" to a common resolution name like "vga" or "uxvga" (afaik maximum resolution supported).