### PR TITLE
Config fix

### DIFF
--- a/doorpi/conf/config_object.py
+++ b/doorpi/conf/config_object.py
@@ -130,9 +130,10 @@ class ConfigObject():
         if log: logger.trace("get_boolean for key %s in section %s (default: %s) returns %s", key, section, default, value)
         return value
 
-    def get_list(self, section, key, default = '', separator = ',', log = True):
-        value = self.get(section, key, default, log = False)
-        value = value.split(separator)
+    def get_list(self, section, key, default = [], separator = ',', log = True):
+        value = self.get(section, key, log = False)
+        if value is not '': value = value.split(separator)
+        else: value = default
         if log: logger.trace("get_list for key %s in section %s (default: %s) returns %s", key, section, default, value)
         return value
 


### PR DESCRIPTION
kleiner Bugfix in config_object.py. Wenn für get_list ein default von [] mit übergeben wurde (wie z.B. hier: https://github.com/motom001/DoorPi/blob/master/doorpi/sipphone/pjsua_lib/Config.py#L40) hatte get_list nicht funktioniert.