### PR TITLE
new (SysV) init script, closes #84

### DIFF
--- a/docs/service/doorpi
+++ b/docs/service/doorpi
@@ -1,43 +1,40 @@
-#! /bin/bash
-#
-# /etc/init.d/doorpi
-#
+#!/bin/sh
+# kFreeBSD do not accept scripts as interpreters, using #!/bin/sh and sourcing.
+if [ true != "$INIT_D_SCRIPT_SOURCED" ] ; then
+    set "$0" "$@"; INIT_D_SCRIPT_SOURCED=true . /lib/init/init-d-script
+fi
 ### BEGIN INIT INFO
-# Provides: doorpi 
-# Required-Start: $syslog $remote_fs 
-# Required-Stop: $syslog $remote_fs
-# Default-Start: 2 3 4 5 
-# Default-Stop: 0 1 6 
-# Short-Description: DoorPi 
-# Description: VoIP Intercom Service DoorPi
+# Provides:          DoorPi
+# Required-Start:    $remote_fs $syslog
+# Required-Stop:     $remote_fs $syslog
+# Default-Start:     2 3 4 5
+# Default-Stop:      0 1 6
+# Short-Description: DoorPi
+# Description:       VoIP Intercom Service DoorPi
 ### END INIT INFO
 
-DOORPI_PATH=/home/DoorPI
+# Author: Foo Bar <foobar@baz.org>
+#
+# Please remove the "Author" lines above and replace them
+# with your own name if you copy and modify this script.
 
-case "$1" in
-  start)
-    echo "Starting server"
-    # Start the daemon
-    python $DOORPI_PATH/doorpi/main.py start --configfile $DOORPI_PATH/conf/doorpi.cfg
-    ;;
-  stop)
-    echo "Stopping server"
-    # Stop the daemon
-    python $DOORPI_PATH/doorpi/main.py stop
-    ;;
-  restart)
-    echo "Restarting server"
-    $0 stop
-    $0 start
-    ;;
-  status)
-    echo "Query Status:"
-    # query status from doorpi
-    python $DOORPI_PATH/doorpi/main.py status
-    ;;
-  *)
-    # Refuse to do other stuff
-    echo "Usage: $0 {start|stop|restart|status}"
-    exit 1
-    ;; esac
-exit 0
+NAME=DoorPi
+DESC="VoIP Intercom Service"
+DOORPI_PATH=/home/DoorPI
+DAEMON=$DOORPI_PATH/doorpi/main.py
+DAEMON_ARGS="--configfile $DOORPI_PATH/conf/doorpi.cfg"
+PIDFILE=/var/run/doorpi.pid
+
+do_start_cmd()
+{
+        status_of_proc "$DAEMON" "$NAME" > /dev/null && return 1
+       	$DAEMON start $DAEMON_ARGS || return 2
+}
+
+do_stop_cmd()
+{
+	status_of_proc "$DAEMON" "$NAME" > /dev/null || return 1
+	$DAEMON stop || return 2
+	rm -f $PIDFILE
+	return 0
+}

--- a/doorpi/main.py
+++ b/doorpi/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/python
 # -*- coding: utf-8 -*-
 
 import argparse
@@ -135,8 +135,8 @@ def main_as_daemon(argv):
     #This ensures that the logger file handle does not get closed during daemonization
     daemon_runner.daemon_context.files_preserve = files_preserve_by_path(DEFAULT_LOG_FILENAME)
     try:
-        logger.info('loaded with arguments: %s', str(argv))
         daemon_runner.do_action()
+        logger.info('loaded with arguments: %s', str(argv))
     except DaemonRunnerStopFailureError as ex:
         print "can't stop DoorPi daemon - maybe it's not running? (Message: %s)" % ex
         return 1


### PR DESCRIPTION
neues SysV kompatibles Initskript. Erkennt normalerweise beim "status" Aufruf sogar ein nicht als Dienst gestartetes DoorPi.

Den shebang in der main.py musste ich minimal ändern, sonst funktioniert der status-Test nicht richtig.
Die Logzeile habe ich verschoben damit sie beim Dienst-Start nicht ausgegeben wird. Sieht meiner Ansicht nach schöner aus ;).