### PR TITLE
Neue Aktion take_snapshot, neues Event BeforeSipPhoneMakeCall und neuer mailto parameter

### DIFF
--- a/doorpi/action/SingleActions/mailto.py
+++ b/doorpi/action/SingleActions/mailto.py
@@ -64,7 +64,7 @@ def fire_action_mail(smtp_to, smtp_subject, smtp_text, smtp_snapshot):
 def createSnapshot():
     snapshot_file = '/tmp/doorpi.jpg'
     size = doorpi.DoorPi().config.get_string('SIP-Phone', 'video_size', '1280x720')
-    os.system("fswebcam --top-banner --font luxisr:20 -r " + size + " " + snapshot_file)
+    os.system("fswebcam --no-banner -r " + size + " " + snapshot_file)
     return snapshot_file
 
 def get(parameters):

--- a/doorpi/action/SingleActions/take_snapshot.py
+++ b/doorpi/action/SingleActions/take_snapshot.py
@@ -25,6 +25,8 @@ def take_snapshot(size, path, max):
         lastNr = int(lastFile[:lastFile.rfind(".jpg")])
         if (lastNr+1 <= max):
             lastNr = lastNr + 1
+	else:
+	    lastNr = 1
     imageFilename = path + str(lastNr) + ".jpg"
     logger.info('create snapshot: %s', imageFilename)
     # fswebcam automatically selects the first video device

--- a/doorpi/action/SingleActions/take_snapshot.py
+++ b/doorpi/action/SingleActions/take_snapshot.py
@@ -11,6 +11,7 @@ DOORPI_SECTION = 'DoorPi'
 
 from action.base import SingleAction
 import doorpi
+import subprocess as sub
 
 conf = doorpi.DoorPi().config
 
@@ -28,10 +29,16 @@ def take_snapshot(size, path, max):
 	else:
 	    lastNr = 1
     imageFilename = path + str(lastNr) + ".jpg"
-    logger.info('create snapshot: %s', imageFilename)
     # fswebcam automatically selects the first video device
-    os.system("fswebcam --top-banner --font luxisr:20 -b -r " + size + " " + imageFilename)
-    return imageFilename
+    command = "fswebcam --top-banner -b --font luxisr:20 -r " + size + " " + imageFilename
+    p = sub.Popen(command, shell=True, stdout=sub.PIPE, stderr=sub.PIPE)
+    output, errors = p.communicate()
+    if (len(errors) > 0):
+        logger.error('error creating snapshot - maybe fswebcam is missing')
+    else:
+        logger.info('snapshot created: %s', imageFilename)
+    return
+
 
 def getLastFilename(path):
     files = [s for s in os.listdir(path)

--- a/doorpi/action/SingleActions/take_snapshot.py
+++ b/doorpi/action/SingleActions/take_snapshot.py
@@ -43,7 +43,7 @@ def getLastFilename(path):
 
 def get(parameters):
     conf = doorpi.DoorPi().config
-    video_size = conf.get_string(SIPPHONE_SECTION, 'video_size', '720p')
+    video_size = conf.get_string(SIPPHONE_SECTION, 'video_size', '1280x720')
     snapshot_path = conf.get_string_parsed(DOORPI_SECTION, 'snapshot_path', '!BASEPATH!/../DoorPiWeb/snapshots/')
     number_of_snapshots = conf.get_int(DOORPI_SECTION, 'number_of_snapshots', 10)
 

--- a/doorpi/action/SingleActions/take_snapshot.py
+++ b/doorpi/action/SingleActions/take_snapshot.py
@@ -50,12 +50,12 @@ def getLastFilename(path):
 
 def get(parameters):
     conf = doorpi.DoorPi().config
-    video_size = conf.get_string(SIPPHONE_SECTION, 'video_size', '1280x720')
+    snapshot_size = conf.get_string(DOORPI_SECTION, 'snapshot_size', '1280x720')
     snapshot_path = conf.get_string_parsed(DOORPI_SECTION, 'snapshot_path', '!BASEPATH!/../DoorPiWeb/snapshots/')
     number_of_snapshots = conf.get_int(DOORPI_SECTION, 'number_of_snapshots', 10)
 
-    if conf.get_bool(SIPPHONE_SECTION, 'video_display_enabled', 'False'):
-        return SnapShotAction(take_snapshot, size = video_size, path = snapshot_path, max = number_of_snapshots)
+    if len(conf.get(SIPPHONE_SECTION, 'capture_device', '')) > 0:
+        return SnapShotAction(take_snapshot, size = snapshot_size, path = snapshot_path, max = number_of_snapshots)
     logger.warning('can not create snapshot - video disabled')
 
 class SnapShotAction(SingleAction):

--- a/doorpi/action/SingleActions/take_snapshot.py
+++ b/doorpi/action/SingleActions/take_snapshot.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+logger = logging.getLogger(__name__)
+logger.debug("%s loaded", __name__)
+
+SIPPHONE_SECTION = 'SIP-Phone'
+DOORPI_SECTION = 'DoorPi'
+
+from action.base import SingleAction
+import doorpi
+
+conf = doorpi.DoorPi().config
+
+def take_snapshot(size, path, max):
+    if not os.path.exists(path):
+        logger.info('Path (%s) does not exist - creating it now', path)
+        os.makedirs(path)
+
+    lastFile = getLastFilename(path)
+    lastNr = 1
+    if (len(lastFile) > 0):
+        lastNr = int(lastFile[:lastFile.rfind(".jpg")])
+        if (lastNr+1 <= max):
+            lastNr = lastNr + 1
+    imageFilename = path + str(lastNr) + ".jpg"
+    logger.info('create snapshot: %s', imageFilename)
+    # fswebcam automatically selects the first video device
+    os.system("fswebcam --top-banner --font luxisr:20 -b -r " + size + " " + imageFilename)
+    return imageFilename
+
+def getLastFilename(path):
+    files = [s for s in os.listdir(path)
+         if os.path.isfile(os.path.join(path, s))]
+    files.sort(key=lambda s: os.path.getmtime(os.path.join(path, s)))
+    if (len(files) == 0):
+        return ''
+    return files[len(files)-1]
+
+def get(parameters):
+    conf = doorpi.DoorPi().config
+    video_size = conf.get_string(SIPPHONE_SECTION, 'video_size', '720p')
+    snapshot_path = conf.get_string_parsed(DOORPI_SECTION, 'snapshot_path', '!BASEPATH!/../DoorPiWeb/snapshots/')
+    number_of_snapshots = conf.get_int(DOORPI_SECTION, 'number_of_snapshots', 10)
+
+    if conf.get_bool(SIPPHONE_SECTION, 'video_display_enabled', 'False'):
+        return SnapShotAction(take_snapshot, size = video_size, path = snapshot_path, max = number_of_snapshots)
+    logger.warning('can not create snapshot - video disabled')
+
+class SnapShotAction(SingleAction):
+    pass

--- a/doorpi/sipphone/from_linphone.py
+++ b/doorpi/sipphone/from_linphone.py
@@ -148,6 +148,7 @@ class LinPhone(SipphoneAbstractBaseClass):
         DoorPi().event_handler.register_event('OnSipPhoneRecorderCreate', __name__)
         DoorPi().event_handler.register_event('OnSipPhoneRecorderDestroy', __name__)
 
+        DoorPi().event_handler.register_event('BeforeSipPhoneMakeCall', __name__)
         DoorPi().event_handler.register_event('OnSipPhoneMakeCall', __name__)
         DoorPi().event_handler.register_event('OnSipPhoneMakeCallFailed', __name__)
         DoorPi().event_handler.register_event('AfterSipPhoneMakeCall', __name__)
@@ -307,6 +308,7 @@ class LinPhone(SipphoneAbstractBaseClass):
                 DoorPi().event_handler('OnSipPhoneCallTimeoutMaxCalltime', __name__)
 
     def call(self, number):
+        DoorPi().event_handler('BeforeSipPhoneMakeCall', __name__, {'number':number})
         logger.debug("call (%s)",str(number))
         if not self.current_call:
             logger.debug('no current call -> start new call')
@@ -344,3 +346,4 @@ class LinPhone(SipphoneAbstractBaseClass):
             self.core.terminate_call(self.current_call)
         else:
             logger.debug("Ignoring hangup request as there is no ongoing call")
+

--- a/doorpi/sipphone/from_pjsua.py
+++ b/doorpi/sipphone/from_pjsua.py
@@ -86,6 +86,7 @@ class Pjsua(SipphoneAbstractBaseClass):
         DoorPi().event_handler.register_event('OnSipPhoneRecorderCreate', __name__)
         DoorPi().event_handler.register_event('OnSipPhoneRecorderDestroy', __name__)
 
+        DoorPi().event_handler.register_event('BeforeSipPhoneMakeCall', __name__)
         DoorPi().event_handler.register_event('OnSipPhoneMakeCall', __name__)
         DoorPi().event_handler.register_event('AfterSipPhoneMakeCall', __name__)
         
@@ -205,9 +206,9 @@ class Pjsua(SipphoneAbstractBaseClass):
                 pass
 
     def call(self, number):
-
+        DoorPi().event_handler('BeforeSipPhoneMakeCall', __name__, {'number':number})
         logger.debug("call(%s)",str(number))
-        DoorPi().event_handler('OnSipPhoneMakeCall', __name__)
+
         self.lib.thread_register('call_theard')
 
         sip_server = pjsua_lib.Config.sipphone_server()
@@ -219,6 +220,7 @@ class Pjsua(SipphoneAbstractBaseClass):
         else:
             logger.debug("SIP-URI %s is valid", sip_uri)
 
+        DoorPi().event_handler('OnSipPhoneMakeCall', __name__)
         if not self.current_call or self.current_call.is_valid() is 0:
             lck = self.lib.auto_lock()
             self.current_callcallback = pjsua_lib.SipPhoneCallCallBack.SipPhoneCallCallBack()
@@ -272,3 +274,4 @@ class Pjsua(SipphoneAbstractBaseClass):
             self.lib.hangup_all()
         else:
             logger.debug("Ignoring hangup request as there is no ongoing call")
+

--- a/doorpi/status/requirements_lib/req_sipphone.py
+++ b/doorpi/status/requirements_lib/req_sipphone.py
@@ -16,6 +16,7 @@ REQUIREMENT = dict(
         dict( name = 'OnSipPhoneDestroy', description = 'Das SIP-Phone soll beendet werden.'),
         dict( name = 'OnSipPhoneRecorderCreate', description = 'Es wurde eine Recorder erstellt wurde und bereit ist Anrufe aufzuzeichnen.'),
         dict( name = 'OnSipPhoneRecorderDestroy', description = 'Es wurde ein Recorder gestoppt und es sind keine weiteren Aufnamen möglich.'),
+        dict( name = 'BeforeSipPhoneMakeCall', description = 'Kurz bevor ein Gespräch von DoorPi aus gestartet wird.'),
         dict( name = 'OnSipPhoneMakeCall', description = 'Es wird ein Gespräch von DoorPi aus gestartet.'),
         dict( name = 'OnSipPhoneMakeCallFailed', description = 'Es ist ein Fehler aufgetreten, als ein Gespräch von DoorPi aus gestartet werden sollte.'),
         dict( name = 'AfterSipPhoneMakeCall', description = 'Das Gespräch wurde hergestellt und es klingelt an der Gegenstelle'),
@@ -65,6 +66,8 @@ REQUIREMENT = dict(
         dict( section = SIPPHONE_SECTION, key = 'dialtone_volume', type = 'integer', default = '35', mandatory = False, description = 'Lautstärke des DialTone, der erzeugt werden soll (in %).'),
         dict( section = SIPPHONE_SECTION, key = 'records', type = 'string', default = '', mandatory = False, description = 'Ablagepfad der aufgenommenen Gespräche (z.B. !BASEPATH!/records/!LastKey!/%Y-%m-%d_%H-%M-%S.wav)'),
         dict( section = SIPPHONE_SECTION, key = 'record_while_dialing', type = 'string', default = 'False', mandatory = False, description = 'Soll das Gespräch schon aufgenommen werden, wenn es klingelt (True) oder erst wenn die Gegenseite abgenommmen hat (False). Im Fall von verpassten Anrufen kann man aufgrund der Geräusche den Besucher eventuell erkennen.'),
+        dict( section = SIPPHONE_SECTION, key = 'snapshot_path', type = 'string', default = '!Basepath!/doorpi/media/snapshots', mandatory = False, description = 'Ablagepfad der erstellten Bilder vor dem Läuten (z.B. !BASEPATH!/doorpi/media/snapshots)'),
+        dict( section = SIPPHONE_SECTION, key = 'number_of_snapshots', type = 'integer', default = '10', mandatory = False, description = 'Anzahl der Bilder die gespeichert werden.')
     ],
     libraries = dict(
         linphone = dict(
@@ -146,3 +149,4 @@ Für den Betrieb hinter einem NAT-Router steht das STUN-Protokoll zur Verfügung
         )
     )
 )
+

--- a/doorpi/status/status_class.py
+++ b/doorpi/status/status_class.py
@@ -18,6 +18,7 @@ MODULES = [
     'sipphone',
     'event_handler',
     'history_event',
+    'history_snapshot',
     #'history_action',
     'environment',
     'webserver'

--- a/doorpi/status/status_lib/history_snapshot.py
+++ b/doorpi/status/status_lib/history_snapshot.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import logging
+import os
+logger = logging.getLogger(__name__)
+logger.debug("%s loaded", __name__)
+
+DOORPI_SECTION = 'DoorPi'
+
+def get(*args, **kwargs):
+    try:
+	if len(kwargs['name']) == 0: kwargs['name'] = ['']
+        if len(kwargs['value']) == 0: kwargs['value'] = ['']
+
+        path = kwargs['DoorPiObject'].config.get_string_parsed(DOORPI_SECTION, 'snapshot_path')
+ 	
+	if (os.path.exists(path)):
+	    files = [os.path.join(path,i) for i in os.listdir(path)]
+	    files = sorted(files, key=os.path.getmtime)
+            # because path is added by webserver automatically
+	    if (path.find('DoorPiWeb')):
+            	changedpath = path[path.find('DoorPiWeb')+len('DoorPiWeb'):]
+            	files = [f.replace(path, changedpath) for f in files]
+        return files
+
+    except Exception as exp:
+        logger.exception(exp)
+        return {'Error': 'could not create '+str(__name__)+' object - '+str(exp)}


### PR DESCRIPTION
Ich habe die Features nun "ausreichend" getestet - mit Vorbehalt. Wenn du Zeit hast kannst du das gerne mal testen und ins Master übernehmen. Für die Anpassungen im DoorPiWeb gibt es einen eigenen PullRequest. Damit take_snapshot funktioniert muss fswebcam installiert werden!
sudo apt-get install fswebcam

take_snapshot Aktion:
Die take_snapshot Aktion nimmt ein Bild von der Kamera auf und speichert das Bild in den konfigurierten Ordner. Damit dass Bild im DoorPiWeb dargestellt werden kann muss sich der Ordner im DoorPiWeb Pfad befinden. Folgende Konfigurationen in der Sektion [DoorPi] sind für take_snapshot möglich:
snapshot_path (default: !BASEPATH!/../DoorPiWeb/snapshots/) ... Speicherort
number_of_snapshots (default: 10) ... Anzahl der Snapshots die gespeichert werden (Ringspeicher)
snapshot_size (default: 1280x720) .. definiert die Größe des Bildes

mailto Aktion Erweiterung:
Nun ist es mittels zusätzlichen booleschen Parameter möglich ein Bild von der Kamera direkt per Mail zu versenden. Dabei wird das Bild im /tmp/ Ordner gespeichert und als Anhang der Mail mitgesendet.
zB: mailto:doorpi.rulez@gmail.com,DoorPi,Someone is ringing!,True
True bedeutet, dass ein Bild mitgesendet wird.

Event:
[EVENT_BeforeSipPhoneMakeCall] --> kurz bevor Call Event aufgerufen wird

Konfigurationsbeispiel:
[EVENT_OnSipPhoneMakeCall]
10 = sleep:10
20 = mailto:doorpi.rulez@gmail.com,DoorPi,Someone is ringing!,True

[EVENT_BeforeSipPhoneMakeCall]
10 = take_snapshot

