### PR TITLE
Möglichkeit der Admin-Nummern erweitert um '*'. 

### DIFF
--- a/doorpi/sipphone/from_pjsua.py
+++ b/doorpi/sipphone/from_pjsua.py
@@ -259,10 +259,15 @@ class Pjsua(SipphoneAbstractBaseClass):
 
         possible_admin_numbers = DoorPi().config.get_keys('AdminNumbers')
         for admin_number in possible_admin_numbers:
+            if admin_number == "*":
+                logger.info("admin numbers are deactivated by using '*' as single number")
+                return True
             if "sip:"+admin_number+"@" in remote_uri:
                 logger.debug("%s is an adminnumber", remote_uri)
                 return True
-
+            if "sip:"+admin_number is remote_uri:
+                logger.debug("%s is adminnumber %s", remote_uri, admin_number)
+                return True
         logger.debug("%s is not an adminnumber", remote_uri)
         return False
 

--- a/doorpi/sipphone/linphone_lib/CallBacks.py
+++ b/doorpi/sipphone/linphone_lib/CallBacks.py
@@ -44,6 +44,9 @@ class LinphoneCallbacks:
     def is_admin_number(self, remote_uri):
         logger.debug("is_admin_number (%s)",remote_uri)
         for admin_number in self.whitelist:
+            if admin_number == "*":
+                logger.info("admin numbers are deactivated by using '*' as single number")
+                return True
             if "sip:"+admin_number+"@" in remote_uri:
                 logger.debug("%s is adminnumber %s", remote_uri, admin_number)
                 return True


### PR DESCRIPTION
Dadurch kann die Prüfung vollständig deaktiviert werden. Achtung - das könnte somit ein Sicherheitsrisiko darstellen!
Eintrag in der Config:
```
[AdminNumbers]
* = active
```
Quelle: http://board.doorpi.org/Thema-52-AdminNumbers.html