### PR TITLE
Adjusted a few minot things to make doorpi work with pjsua again

### DIFF
--- a/doorpi/sipphone/from_pjsua.py
+++ b/doorpi/sipphone/from_pjsua.py
@@ -177,10 +177,10 @@ class Pjsua(SipphoneAbstractBaseClass):
             DoorPi().event_handler.unregister_source(__name__, True)
             return
 
-    def self_check(self, timeout):
+    def self_check(self, *args, **kwargs):
         self.lib.thread_register('pjsip_handle_events')
 
-        self.lib.handle_events(timeout)
+        self.lib.handle_events(self.call_timeout)
 
         if self.current_call is not None:
             if self.current_call.is_valid() is 0:
@@ -214,7 +214,7 @@ class Pjsua(SipphoneAbstractBaseClass):
 
         if self.lib.verify_sip_url(sip_uri) is not 0:
             logger.warning("SIP-URI %s is not valid (Errorcode: %s)", sip_uri, self.lib.verify_sip_url(sip_uri))
-            return false
+            return False
         else:
             logger.debug("SIP-URI %s is valid", sip_uri)
 

--- a/doorpi/sipphone/pjsua_lib/Config.py
+++ b/doorpi/sipphone/pjsua_lib/Config.py
@@ -18,7 +18,7 @@ def max_call_time():
     return conf.get_int(SIPPHONE_SECTION, 'max_call_time', 120)
 
 def sipphone_server():
-    return conf.get(SIPPHONE_SECTION, 'server')
+    return conf.get(SIPPHONE_SECTION, 'sipserver_server')
 
 def pj_log(level, msg, length):
     # beautify output - remove date / time an line break


### PR DESCRIPTION
I wanted to replace linphone by pjsua on my doorpi because the much better CPU performance. Unfortunately it did not work out of the box.
The small adjustments contained in this pull request made the pjsua library cooperate with doorpi, again.

Unfortunately the pjsua interface seems to suffer from a memory leak. I will try to pinpoint its cause.
Video does not work with pjsua, either.