### PR TITLE
add support for linphone's mic_gain_db parameter

### DIFF
--- a/doorpi/sipphone/from_linphone.py
+++ b/doorpi/sipphone/from_linphone.py
@@ -203,6 +203,7 @@ class LinPhone(SipphoneAbstractBaseClass):
         else:
             self.core.capture_device = conf.get(SIPPHONE_SECTION, 'capture_device', self.core.capture_device)
             self.core.playback_device = conf.get(SIPPHONE_SECTION, 'playback_device', self.core.playback_device)
+            self.core.mic_gain_db = conf.get_float(SIPPHONE_SECTION, 'mic_gain_db', 0)
             logger.info("found %s possible sounddevices:", len(self.core.sound_devices))
             logger.debug("|rec|play| name")
             logger.debug("------------------------------------")
@@ -215,6 +216,7 @@ class LinPhone(SipphoneAbstractBaseClass):
             logger.debug("------------------------------------")
             logger.debug("using capture_device: %s", self.core.capture_device)
             logger.debug("using playback_device: %s", self.core.playback_device)
+            logger.debug("mic_gain_db: %s", self.core.mic_gain_db)
 
         # Only enable PCMU and PCMA audio codecs by default
         config_audio_codecs = conf.get_list(SIPPHONE_SECTION, 'audio_codecs', 'PCMA,PCMU')

--- a/doorpi/status/requirements_lib/req_sipphone.py
+++ b/doorpi/status/requirements_lib/req_sipphone.py
@@ -122,6 +122,7 @@ Für den Betrieb hinter einem NAT-Router steht das STUN-Protokoll zur Verfügung
                 dict( section = SIPPHONE_SECTION, key = 'video_size', type = 'string', default = '', mandatory = False, description = 'möglich Werte: [fehlt noch]'),
                 dict( section = SIPPHONE_SECTION, key = 'video_codecs', type = 'array', default = 'VP8', mandatory = False, description = 'Video-Codecs die aktiviert und genutzt werden können.'),
                 dict( section = SIPPHONE_SECTION, key = 'capture_device', type = 'string', default = '', mandatory = False, description = 'Audiogerät, das für die Aufnahme genutzt wird - wenn nichts angegeben wird, dann wird das erst Beste genutzt. Bitte dazu in der LOG-Datei nach "possible sounddevices:" suchen'),
+                dict( section = SIPPHONE_SECTION, key = 'mic_gain_db', type = 'float', default = '0', mandatory = False, description = 'Zusätzliche Software-Verstärkung der Aufnahme, falls der Pegel vom Mikro auch bei maximaler Mixer-Einstellung zu schwach ist.'),
                 dict( section = SIPPHONE_SECTION, key = 'playback_device', type = 'string', default = '', mandatory = False, description = 'Audiogerät, das für die Aufnahme genutzt wird - wenn nichts angegeben wird, dann wird das erst Beste genutzt. Bitte dazu in der LOG-Datei nach "possible sounddevices:" suchen'),
                 dict( section = SIPPHONE_SECTION, key = 'audio_codecs', type = 'array', default = 'PCMA,PCMU', mandatory = False, description = 'Audio-Codecs die aktiviert und genutzt werden können.'),
             ],


### PR DESCRIPTION
In my setup with an old SoundBlaster X-Fi Go! and a König CMP-MIC8, ALSA
maximum for the microphone is not enough. Thankfully, linphone supports
internal software amplification with the "mic_gain_db" parameter. This patch
adds support for setting it in doorpi.ini.