### PR TITLE
setup.py: support pip >= 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,12 @@ def read(filename, parse_file_content=False, new_filename=None):
 
 
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+
+try: # for pip >= 10
+    from pip._internal.req import parse_requirements
+except ImportError: # for pip <= 9.0.3
+    from pip.req import parse_requirements
+    
 install_reqs = parse_requirements(os.path.join(base_path, 'requirements.txt'), session=uuid.uuid1())
 reqs = [str(req.req) for req in install_reqs]
 


### PR DESCRIPTION
DoorPi is not installable from GitHub on Raspbian Stretch because the version of pip.

see also:
https://stackoverflow.com/a/49867265